### PR TITLE
Link to latest version of the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To use this cookiecutter you should have at least.
 
 ## Cookiecutter
 
-1. Cookiecutter - More details how to use and install [here](https://cookiecutter.readthedocs.io/en/1.7.2/)
+1. Cookiecutter - More details how to use and install [here](https://cookiecutter.readthedocs.io/en/latest/)
 
 ## Task Manager
 


### PR DESCRIPTION
Seems sensible to link to the latest version of the docs as currently you hit the docs & get a message that they're not the latest version.